### PR TITLE
rFVS: declare UTF-8 encoding in DESCRIPTION

### DIFF
--- a/rFVS/DESCRIPTION
+++ b/rFVS/DESCRIPTION
@@ -9,3 +9,4 @@ Depends: R (>= 4.0.0)
 License: MIT
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Encoding: UTF-8


### PR DESCRIPTION
rFVS is roxygen2-managed (`Roxygen` / `RoxygenNote` set; no committed
`NAMESPACE` or `man/`), so its documentation is regenerated with
`roxygen2::roxygenize()`. Under roxygen2 8.0.0 that step warns because
DESCRIPTION declares no `Encoding:`

```
✖ roxygen2 requires "Encoding: UTF-8"
ℹ Current encoding is NA
```

Adding `Encoding: UTF-8` silences it (verified: present without the
field, gone with it). It is the value `roxygen2` itself requests, and
the sibling `fvsOL/DESCRIPTION` already declares it — this brings rFVS
in line.

Note: unrelated to non-ASCII content — rFVS sources are pure ASCII, so
no `R CMD check` encoding NOTE is involved. This is purely the
`roxygen2` doc-regeneration warning.