### PR TITLE
fvsOL: fix RSQLite drift in temp-table writes

### DIFF
--- a/fvsOL/R/externalCallable.R
+++ b/fvsOL/R/externalCallable.R
@@ -71,7 +71,7 @@ extnMakeRun <- function (prjDir=getwd(),title=NULL,standIDs=NULL,
   dbExecute(dbcon,'drop table if exists temp.Stds')
   qry = paste0("select ",paste(fields,collapse=",")," from ",stdInit, 
     ' where lower(variant) like "%',tolower(variant),'%"')
-  dbWriteTable(dbcon,DBI::SQL("temp.Stds"),data.frame(SelStds = standIDs))
+  dbWriteTable(dbcon,"Stds",data.frame(SelStds = standIDs),temporary=TRUE,overwrite=TRUE)
   qry = paste0(qry," and ",sidid," in (select SelStds from temp.Stds)")
   
   fvsInit = try(dbGetQuery(dbcon,qry))
@@ -847,7 +847,7 @@ extnAddStands <- function(prjDir=getwd(),runUUID,stands,
             unlist(lapply(fvsRun$stands,function(x) x$sid))))
   if (nrow(getStds) == 0) return(nadd)
     
-  dbWriteTable(dbcon,name=DBI::SQL("temp.getStds"),value=getStds,overwrite=TRUE)
+  dbWriteTable(dbcon,name="getStds",value=getStds,temporary=TRUE,overwrite=TRUE)
   variant = substring(fvsRun$FVSpgm,4)
   dbExecute(dbcon,'drop table if exists temp.Stds')
   qry = paste0("select ",paste(fields,collapse=",")," from ",stdInit, 

--- a/fvsOL/R/fvsRunUtilities.R
+++ b/fvsOL/R/fvsRunUtilities.R
@@ -1339,7 +1339,7 @@ cat ("globals$fvsRun$refreshDB=",globals$fvsRun$refreshDB,"\n")
       dbExecute(dbGlb$dbIcon,'drop table if exists temp.Stds') 
       if (length(input$inStds))
       {
-        dbWriteTable(dbGlb$dbIcon,DBI::SQL("temp.Stds"),data.frame(SelStds = input$inStds))
+        dbWriteTable(dbGlb$dbIcon,"Stds",data.frame(SelStds = input$inStds),temporary=TRUE,overwrite=TRUE)
       } else return()
     } else {
       # use if inAddGrp
@@ -1356,7 +1356,7 @@ cat ("globals$fvsRun$refreshDB=",globals$fvsRun$refreshDB,"\n")
       } 
       if (length(stds) == 0) return()  
       dbExecute(dbGlb$dbIcon,'drop table if exists temp.Stds') 
-      dbWriteTable(dbGlb$dbIcon,DBI::SQL("temp.Stds"),data.frame(SelStds = stds))
+      dbWriteTable(dbGlb$dbIcon,"Stds",data.frame(SelStds = stds),temporary=TRUE,overwrite=TRUE)
     }
     qry = paste0('select ',paste0(fields,collapse=","),' from ',stdInit,
                  ' where ',sidid,' in (select SelStds from temp.Stds)')

--- a/fvsOL/R/server.R
+++ b/fvsOL/R/server.R
@@ -4823,10 +4823,9 @@ cat ("in buildKeywords, oReopn=",oReopn," kwPname=",kwPname,"\n")
              "where KeywordFile = '",globals$fvsRun$uuid,"';"))
          if (nrow(cases) == 0) return()
 cat ("download run as xlsx, ncases=",nrow(cases),"\n")
-         tmp = paste0("tmp",gsub("-","",runuuid),Sys.getpid(),"genoutput")
-         dbExecute(dbGlb$dbOcon,paste0("attach database ':memory:' as ",tmp))
-         casesToGet = paste0(tmp,".casesToGet")
-         dbWriteTable(dbGlb$dbOcon,name=DBI::SQL(casesToGet),value=cases,overwirte=TRUE)
+         casesToGet = "temp.casesToGet"
+         dbExecute(dbGlb$dbOcon,"drop table if exists temp.casesToGet")
+         dbWriteTable(dbGlb$dbOcon,"casesToGet",cases,temporary=TRUE,overwrite=TRUE)
          out = list()
          cmpYes = if ("CmpMetaData" %in% tabs) 
          { 
@@ -4845,7 +4844,6 @@ cat ("download run as xlsx, ncases=",nrow(cases),"\n")
           out[[tab]] = dat
 cat ("qry=",qry," class(dat)=",class(dat),"\n")
          }
-         dbExecute(dbGlb$dbOcon,paste0("detach database ",tmp,";"))
          if (length(out)) write.xlsx(file=tf,out)
        }, contentType=NULL)
   ## dlPrjBackup

--- a/fvsOL/R/server.R
+++ b/fvsOL/R/server.R
@@ -2480,7 +2480,7 @@ cat ("in reloadStandSelection\n")
     if (class(grps) == "try-error" || is.null(grps) || nrow(grps) == 0)
     {
       dbExecute(dbGlb$dbIcon,"drop table if exists temp.Grps")
-      dbWriteTable(dbGlb$dbIcon,DBI::SQL("temp.Grps"),data.frame(Stand_ID="",Grp=""))
+      dbWriteTable(dbGlb$dbIcon,"Grps",data.frame(Stand_ID="",Grp=""),temporary=TRUE,overwrite=TRUE)
       updateSelectInput(session=session, inputId="inGrps",choices=list())
       updateSelectInput(session=session, inputId="ExtGroups",choices=list())
       updateSelectInput(session=session, inputId="inStds",list())
@@ -2514,7 +2514,7 @@ cat ("in reloadStandSelection\n")
                            "StandPlot_ID" else "Stand_ID","Grp")      
       dd = as.data.frame(dd)
       dbExecute(dbGlb$dbIcon,"drop table if exists temp.Grps")
-      dbWriteTable(dbGlb$dbIcon,DBI::SQL("temp.Grps"),dd)
+      dbWriteTable(dbGlb$dbIcon,"Grps",dd,temporary=TRUE,overwrite=TRUE)
       selGrp = dbGetQuery(dbGlb$dbIcon,
         'select distinct Grp from temp.Grps order by Grp')[,1]
 
@@ -2545,7 +2545,7 @@ cat ("inGrps inAnyAll inStdFindBut\n")
         updateSelectInput(session=session, inputId="inStds", choices=list())
       } else {  
          dbExecute(dbGlb$dbIcon,"drop table if exists temp.SGrps")
-         dbWriteTable(dbGlb$dbIcon,DBI::SQL("temp.SGrps"),data.frame(SelGrps = input$inGrps))
+         dbWriteTable(dbGlb$dbIcon,"SGrps",data.frame(SelGrps = input$inGrps),temporary=TRUE,overwrite=TRUE)
          sid = if (input$inTabs %in% c("FVS_PlotInit","FVS_PlotInit_Plot"))
                "StandPlot_ID" else "Stand_ID"
          stds = try(dbGetQuery(dbGlb$dbIcon,paste0('select ',sid,' from temp.Grps ',
@@ -2584,7 +2584,7 @@ cat ("input$inStdFind=",input$inStdFind,"\n")
     }
     else{
       dbExecute(dbGlb$dbIcon,"drop table if exists temp.SEGrps")
-      dbWriteTable(dbGlb$dbIcon,DBI::SQL("temp.SEGrps"),data.frame(SelGrps = input$ExtGroups))
+      dbWriteTable(dbGlb$dbIcon,"SEGrps",data.frame(SelGrps = input$ExtGroups),temporary=TRUE,overwrite=TRUE)
       sid = if (input$inTabs %in% c("FVS_PlotInit","FVS_PlotInit_Plot"))"StandPlot_ID" else "Stand_ID"
       stds = try(dbGetQuery(dbGlb$dbIcon,paste0('select distinct ',sid,' from temp.Grps ',
                       'where Grp in (select SelGrps from temp.SEGrps)')))
@@ -5644,7 +5644,7 @@ cat ("mapDsRunList input$mapDsRunList=",input$mapDsRunList,"\n")
       # if there are reps (same stand more than once), just use the first rep, ignore the others
       cases = cases[!duplicated(cases$StandID),]
       dbExecute(dbGlb$dbOcon,"drop table if exists temp.mapsCases")
-      dbWriteTable(dbGlb$dbOcon,DBI::SQL("temp.mapsCases"),cases[,1,drop=FALSE])
+      dbWriteTable(dbGlb$dbOcon,"mapsCases",cases[,1,drop=FALSE],temporary=TRUE,overwrite=TRUE)
       tabs = setdiff(myListTables(dbGlb$dbOcon),
                      c("CmpSummary","FVS_Cases","CmpSummary_East"))
       tables = list()
@@ -5794,7 +5794,7 @@ cat ("left to get: length(uidsToGet)=",length(uidsToGet),
         })
         if (is.null(inInit)) inInit = getTableName(dbGlb$dbIcon,"FVS_StandInit")
 cat ("mapDsRunList trying to use the table=",inInit,"\n")
-        dbWriteTable(dbGlb$dbIcon,DBI::SQL("temp.uidsToGet"),data.frame(stds=uidsToGet),overwrite=TRUE)
+        dbWriteTable(dbGlb$dbIcon,"uidsToGet",data.frame(stds=uidsToGet),temporary=TRUE,overwrite=TRUE)
         sid = if (inInit %in% c("FVS_PlotInit","FVS_PlotInit_Plot"))
                "StandPlot_ID" else "Stand_ID"
         qry = paste0("select distinct ",sid," as Stand_ID,Latitude,Longitude from ",inInit,

--- a/fvsOL/R/writeKeyFile.R
+++ b/fvsOL/R/writeKeyFile.R
@@ -433,7 +433,7 @@ writeKeyFile <- function (globals,dbIcon,keyFileName=NULL,verbose=TRUE)
   if (length(stds)==0) return(paste0("No stands to process. Run =",
            globals$fvsRun$title," uuid=",globals$fvsRun$uuid))
   dbExecute(dbIcon,'drop table if exists temp.RunStds')                   
-  dbWriteTable(dbIcon,DBI::SQL("temp.RunStds"),data.frame(RunStds = stds))
+  dbWriteTable(dbIcon,"RunStds",data.frame(RunStds = stds),temporary=TRUE,overwrite=TRUE)
  
   # get the preferred ids depending on the table that was used to build the run
   intable=toupper(globals$fvsRun$refreshDB)


### PR DESCRIPTION
On current RSQLite, writing a temp table by passing a schema-qualified
name as `DBI::SQL("temp.X")` fails:

```r
library(DBI); library(RSQLite)
con <- dbConnect(SQLite(), ":memory:")
dbWriteTable(con, DBI::SQL("temp.Grps"), data.frame(Stand_ID = "", Grp = ""))
#> Error: Named parameters not used in query: name
```

Versions (Posit Package Manager snapshot 2026-05-27): R 4.6.0,
RSQLite 3.53.1, DBI 1.3.0, bundled SQLite 3.53.1.

The DBI-idiomatic form works and the table is still queryable as
`temp.X`:

```r
dbWriteTable(con, "Grps", df, temporary = TRUE, overwrite = TRUE)
```

This breaks fvsOL at runtime (stand selection, keyword-file generation,
and the external-callable API all build `temp.*` helper tables). This
PR converts all 11 affected sites:

- `server.R` (6)
- `writeKeyFile.R` (1)
- `externalCallable.R` (2)
- `fvsRunUtilities.R` (2)

Each converted write keeps the base name its downstream queries
reference (e.g. write `"RunStds"` → read `temp.RunStds`).

Update — also covers the Excel-export path (2nd commit). RSQLite ≥ 3 rejects any DBI::SQL() object passed as the dbWriteTable name argument (Error: Named parameters not used in query: name). Beyond the 11 temp.* sites in the first commit, the "Output .xlsx for current run" handler (output$dlFVSOutxlsx in server.R) hit the same error via a dynamic DBI::SQL(casesToGet) name — and carried an overwirte= typo, so overwrite never applied. The second commit converts it to a temporary table (the same temporary=TRUE form as the other sites), drops the now-redundant attached-:memory:-db it used for that one table, and fixes the typo. All DBI::SQL()-as-name dbWriteTable sites in fvsOL (12 total) are now addressed. Verified end-to-end: the .xlsx export works in the WebGUI.